### PR TITLE
add role to users

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+# Motivation
+
+
+# Proposed solution
+

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ group :development, :test do
 
   gem "rspec-rails"
   gem "capybara"
+  gem "factory_bot_rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,11 @@ GEM
     erubi (1.13.0)
     et-orbi (1.2.11)
       tzinfo
+    factory_bot (6.5.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.4.3)
+      factory_bot (~> 6.4)
+      railties (>= 5.0.0)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -376,6 +381,7 @@ DEPENDENCIES
   brakeman
   capybara
   debug
+  factory_bot_rails
   importmap-rails
   jbuilder
   kamal (>= 2.0.0.rc2)

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -4,6 +4,7 @@ module Authentication
   included do
     before_action :require_authentication
     helper_method :authenticated?
+    helper_method :authenticated_user
   end
 
   class_methods do
@@ -15,6 +16,12 @@ module Authentication
   private
     def authenticated?
       Current.session.present?
+    end
+
+    def authenticated_user
+      return unless authenticated?
+
+      Current.session.user
     end
 
     def require_authentication

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,7 @@ class User < ApplicationRecord
   has_secure_password
   has_many :sessions, dependent: :destroy
 
-  normalizes :email_address, with: -> e { e.strip.downcase }
+  normalizes :email_address, with: ->(e) { e.strip.downcase }
+
+  enum :role, { administration: 1, faculty: 2, student: 3 }
 end

--- a/app/views/dashboard/_administration.html.erb
+++ b/app/views/dashboard/_administration.html.erb
@@ -1,0 +1,1 @@
+<h1>Administration Dashboard</h1>

--- a/app/views/dashboard/_faculty.html.erb
+++ b/app/views/dashboard/_faculty.html.erb
@@ -1,0 +1,1 @@
+<h1>Faculty Dashboard</h1>

--- a/app/views/dashboard/_student.html.erb
+++ b/app/views/dashboard/_student.html.erb
@@ -1,0 +1,1 @@
+<h1>Student Dashboard</h1>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,1 +1,1 @@
-<h1>Dashboard</h1>
+<%= render authenticated_user.role %>

--- a/db/migrate/20241006220551_add_role_to_user.rb
+++ b/db/migrate/20241006220551_add_role_to_user.rb
@@ -1,0 +1,5 @@
+class AddRoleToUser < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :role, :integer, limit: 1, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_10_06_212939) do
+ActiveRecord::Schema[8.0].define(version: 2024_10_06_220551) do
   create_table "sessions", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "ip_address"
@@ -25,6 +25,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_10_06_212939) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "role", limit: 1, default: 1
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,20 @@
+TEST_USER_PASSWORD = 'hard-2-guess'
+
+FactoryBot.define do
+  factory :user do
+    email_address { |n| "user#{n}@email.com" }
+    password { TEST_USER_PASSWORD }
+
+    trait :administration do
+      role { :administration }
+    end
+
+    trait :faculty do
+      role { :faculty }
+    end
+
+    trait :student do
+      role { :student }
+    end
+  end
+end

--- a/spec/features/administration_sees_dashboard_spec.rb
+++ b/spec/features/administration_sees_dashboard_spec.rb
@@ -1,0 +1,9 @@
+feature 'administration sees dashboard' do
+  scenario 'sucessfully' do
+    sign_in create(:user, :administration)
+
+    visit root_path
+
+    expect(page).to have_css('h1', text: 'Administration Dashboard')
+  end
+end

--- a/spec/features/faculty_sees_dashboard_spec.rb
+++ b/spec/features/faculty_sees_dashboard_spec.rb
@@ -1,0 +1,9 @@
+feature 'faculty sees dashboard' do
+  scenario 'sucessfully' do
+    sign_in create(:user, :faculty)
+
+    visit root_path
+
+    expect(page).to have_css('h1', text: 'Faculty Dashboard')
+  end
+end

--- a/spec/features/student_sees_dashboard_spec.rb
+++ b/spec/features/student_sees_dashboard_spec.rb
@@ -1,0 +1,9 @@
+feature 'student sees dashboard' do
+  scenario 'sucessfully' do
+    sign_in create(:user, :student)
+
+    visit root_path
+
+    expect(page).to have_css('h1', text: 'Student Dashboard')
+  end
+end

--- a/spec/features/user_sees_dashboard_spec.rb
+++ b/spec/features/user_sees_dashboard_spec.rb
@@ -1,9 +1,0 @@
-feature 'user sees dashboard' do
-  scenario 'sucessfully' do
-    sign_in
-
-    visit root_path
-
-    expect(page).to have_css('h1', text: 'Dashboard')
-  end
-end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,6 +16,7 @@ Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |file| require file
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
+  config.include FactoryBot::Syntax::Methods
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
 end

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -1,6 +1,4 @@
-TEST_USER_PASSWORD = 'hard-2-guess'
-
-def sign_in(user = User.create(email_address: 'user@email.com', password: TEST_USER_PASSWORD))
+def sign_in(user = create(:user))
   visit root_path
 
   fill_in 'email_address', with: user.email_address


### PR DESCRIPTION
# Motivation
School users could be folks working in the office, teachers, or students. What each of these groups can see or do in the application varies.

# Proposed solution
- give `users` a column/attribute that sets them as `administration`, `faculty`, or `student`
- leverage Rails `enum` to keep DB values as small integers and have descriptive, normalized names in code
- create `authenticated_user` helper to support making decisions based on user attributes
- create and use partials for dashboards based on user roles
