### PR TITLE
create courses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem "kamal", ">= 2.0.0.rc2", require: false
 # Add HTTP asset caching/compression and X-Sendfile acceleration to Puma [https://github.com/basecamp/thruster/]
 gem "thruster", require: false
 
+gem "simple_form"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,6 +296,9 @@ GEM
       rubocop-rails
     ruby-progressbar (1.13.0)
     securerandom (0.3.1)
+    simple_form (5.3.1)
+      actionpack (>= 5.2)
+      activemodel (>= 5.2)
     solid_cable (3.0.2)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -390,6 +393,7 @@ DEPENDENCIES
   rails (~> 8.0.0.beta1)
   rspec-rails
   rubocop-rails-omakase
+  simple_form
   solid_cable
   solid_cache
   solid_queue

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,0 +1,15 @@
+class CoursesController < ApplicationController
+  def create
+    @course = Course.new(course_params)
+
+    alert = @course.save ? "created" : "failed"
+
+    redirect_to root_path, alert: alert
+  end
+
+  private
+
+  def course_params
+    params.require(:course).permit(:subject, :teacher_id, :teacher_assistant_id, student_ids: [])
+  end
+end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,4 +1,10 @@
 class DashboardController < ApplicationController
   def index
+    if authenticated_user.administration?
+      @courses = Course.all
+      @new_course = Course.new
+      @teachers = User.faculty
+      @students = User.student
+    end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,0 +1,6 @@
+class Course < ApplicationRecord
+  belongs_to :teacher, -> { faculty }, class_name: "User"
+  belongs_to :teacher_assistant, -> { faculty }, class_name: "User", optional: true
+  has_many :course_students
+  has_many :students, -> { student }, through: :course_students
+end

--- a/app/models/course_student.rb
+++ b/app/models/course_student.rb
@@ -1,0 +1,4 @@
+class CourseStudent < ApplicationRecord
+  belongs_to :course
+  belongs_to :student, -> { student }, class_name: "User"
+end

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -1,0 +1,7 @@
+<%= simple_form_for @new_course do |f| %>
+  <%= f.input :subject %>
+  <%= f.association :teacher, label_method: :email_address, include_blank: false %>
+  <%= f.association :teacher_assistant, label_method: :email_address %>
+  <%= f.association :students, label_method: :email_address, as: :check_boxes %>
+  <%= f.button :submit %>
+<% end %>

--- a/app/views/courses/_list.html.erb
+++ b/app/views/courses/_list.html.erb
@@ -1,0 +1,5 @@
+<ul>
+  <% @courses.each do |course| %>
+    <li><%= course.subject %> <%= course.teacher.email_address %> <%= course.students.count %></li>
+  <% end %>
+</ul>

--- a/app/views/dashboard/_administration.html.erb
+++ b/app/views/dashboard/_administration.html.erb
@@ -1,1 +1,9 @@
 <h1>Administration Dashboard</h1>
+
+<%= tag.div(flash[:alert]) if flash[:alert] %>
+
+<h2>Courses</h2>
+<%= render 'courses/list' %>
+
+<h2>Create new course</h2>
+<%= render 'courses/form' %>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+#
+# Uncomment this and change the path if necessary to include your own
+# components.
+# See https://github.com/heartcombo/simple_form#custom-components to know
+# more about custom components.
+# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+#
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  # Wrappers are used by the form builder to generate a
+  # complete input. You can remove any component from the
+  # wrapper, change the order or even add your own to the
+  # stack. The options given below are used to wrap the
+  # whole input.
+  config.wrappers :default, class: :input,
+    hint_class: :field_with_hint, error_class: :field_with_errors, valid_class: :field_without_errors do |b|
+    ## Extensions enabled by default
+    # Any of these extensions can be disabled for a
+    # given input by passing: `f.input EXTENSION_NAME => false`.
+    # You can make any of these extensions optional by
+    # renaming `b.use` to `b.optional`.
+
+    # Determines whether to use HTML5 (:email, :url, ...)
+    # and required attributes
+    b.use :html5
+
+    # Calculates placeholders automatically from I18n
+    # You can also pass a string as f.input placeholder: "Placeholder"
+    b.use :placeholder
+
+    ## Optional extensions
+    # They are disabled unless you pass `f.input EXTENSION_NAME => true`
+    # to the input. If so, they will retrieve the values from the model
+    # if any exists. If you want to enable any of those
+    # extensions by default, you can change `b.optional` to `b.use`.
+
+    # Calculates maxlength from length validations for string inputs
+    # and/or database column lengths
+    b.optional :maxlength
+
+    # Calculate minlength from length validations for string inputs
+    b.optional :minlength
+
+    # Calculates pattern from format validations for string inputs
+    b.optional :pattern
+
+    # Calculates min and max from length validations for numeric inputs
+    b.optional :min_max
+
+    # Calculates readonly automatically from readonly attributes
+    b.optional :readonly
+
+    ## Inputs
+    # b.use :input, class: 'input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label_input
+    b.use :hint,  wrap_with: { tag: :span, class: :hint }
+    b.use :error, wrap_with: { tag: :span, class: :error }
+
+    ## full_messages_for
+    # If you want to display the full error message for the attribute, you can
+    # use the component :full_error, like:
+    #
+    # b.use :full_error, wrap_with: { tag: :span, class: :error }
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :default
+
+  # Define the way to render check boxes / radio buttons with labels.
+  # Defaults to :nested for bootstrap config.
+  #   inline: input + label
+  #   nested: label > input
+  config.boolean_style = :nested
+
+  # Default class for buttons
+  config.button_class = 'btn'
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # Use :to_sentence to list all errors for each field.
+  # config.error_method = :first
+
+  # Default tag used for error notification helper.
+  config.error_notification_tag = :div
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = 'error_notification'
+
+  # Series of attempts to detect a default label method for collection.
+  # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
+
+  # Series of attempts to detect a default value method for collection.
+  # config.collection_value_methods = [ :id, :to_s ]
+
+  # You can wrap a collection of radio/check boxes in a pre-defined tag, defaulting to none.
+  # config.collection_wrapper_tag = nil
+
+  # You can define the class to use on all collection wrappers. Defaulting to none.
+  # config.collection_wrapper_class = nil
+
+  # You can wrap each item in a collection of radio/check boxes with a tag,
+  # defaulting to :span.
+  # config.item_wrapper_tag = :span
+
+  # You can define a class to use in all item wrappers. Defaulting to none.
+  # config.item_wrapper_class = nil
+
+  # How the label text should be generated altogether with the required text.
+  # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+
+  # You can define the class to use on all labels. Default is nil.
+  # config.label_class = nil
+
+  # You can define the default class to be used on forms. Can be overridden
+  # with `html: { :class }`. Defaulting to none.
+  # config.default_form_class = nil
+
+  # You can define which elements should obtain additional classes
+  # config.generate_additional_classes_for = [:wrapper, :label, :input]
+
+  # Whether attributes are required by default (or not). Default is true.
+  # config.required_by_default = true
+
+  # Tell browsers whether to use the native HTML5 validations (novalidate form option).
+  # These validations are enabled in SimpleForm's internal config but disabled by default
+  # in this configuration, which is recommended due to some quirks from different browsers.
+  # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
+  # change this configuration to true.
+  config.browser_validations = false
+
+  # Custom mappings for input types. This should be a hash containing a regexp
+  # to match as key, and the input type that will be used when the field name
+  # matches the regexp as value.
+  # config.input_mappings = { /count/ => :integer }
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
+  # config.wrapper_mappings = { string: :prepend }
+
+  # Namespaces where SimpleForm should look for custom input classes that
+  # override default inputs.
+  # config.custom_inputs_namespaces << "CustomInputs"
+
+  # Default priority for time_zone inputs.
+  # config.time_zone_priority = nil
+
+  # Default priority for country inputs.
+  # config.country_priority = nil
+
+  # When false, do not use translations for labels.
+  # config.translate_labels = true
+
+  # Automatically discover new inputs in Rails' autoload path.
+  # config.inputs_discovery = true
+
+  # Cache SimpleForm inputs discovery
+  # config.cache_discovery = !Rails.env.development?
+
+  # Default class for inputs
+  # config.input_class = nil
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = 'checkbox'
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  # config.include_default_input_wrapper_class = true
+
+  # Defines which i18n scope will be used in Simple Form.
+  # config.i18n_scope = 'simple_form'
+
+  # Defines validation classes to the input_field. By default it's nil.
+  # config.input_field_valid_class = 'is-valid'
+  # config.input_field_error_class = 'is-invalid'
+end

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #
 # Uncomment this and change the path if necessary to include your own
 # components.
@@ -74,7 +75,7 @@ SimpleForm.setup do |config|
   config.boolean_style = :nested
 
   # Default class for buttons
-  config.button_class = 'btn'
+  config.button_class = "btn"
 
   # Method used to tidy up errors. Specify any Rails Array method.
   # :first lists the first message for each field.
@@ -85,7 +86,7 @@ SimpleForm.setup do |config|
   config.error_notification_tag = :div
 
   # CSS class to add for error notification helper.
-  config.error_notification_class = 'error_notification'
+  config.error_notification_class = "error_notification"
 
   # Series of attempts to detect a default label method for collection.
   # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
@@ -161,7 +162,7 @@ SimpleForm.setup do |config|
   # config.input_class = nil
 
   # Define the default class of the input wrapper of the boolean input.
-  config.boolean_label_class = 'checkbox'
+  config.boolean_label_class = "checkbox"
 
   # Defines if the default input wrapper class should be included in radio
   # collection wrappers.

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,31 @@
+en:
+  simple_form:
+    "yes": 'Yes'
+    "no": 'No'
+    required:
+      text: 'required'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Please review the problems below:"
+    # Examples
+    # labels:
+    #   defaults:
+    #     password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+    # include_blanks:
+    #   defaults:
+    #     age: 'Rather not say'
+    # prompts:
+    #   defaults:
+    #     age: 'Select your age'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   resource :session
   resources :passwords, param: :token
+  resources :courses, only: [ :create ]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20241006230547_create_courses.rb
+++ b/db/migrate/20241006230547_create_courses.rb
@@ -1,0 +1,11 @@
+class CreateCourses < ActiveRecord::Migration[8.0]
+  def change
+    create_table :courses do |t|
+      t.string :subject
+      t.references :teacher, foreign_key: { to_table: :users }, null: false
+      t.references :teacher_assistant, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241006234624_create_course_students.rb
+++ b/db/migrate/20241006234624_create_course_students.rb
@@ -1,0 +1,10 @@
+class CreateCourseStudents < ActiveRecord::Migration[8.0]
+  def change
+    create_table :course_students do |t|
+      t.references :course, null: false, foreign_key: true
+      t.references :student, foreign_key: { to_table: :users }, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_10_06_220551) do
+ActiveRecord::Schema[8.0].define(version: 2024_10_06_234624) do
+  create_table "course_students", force: :cascade do |t|
+    t.integer "course_id", null: false
+    t.integer "student_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["course_id"], name: "index_course_students_on_course_id"
+    t.index ["student_id"], name: "index_course_students_on_student_id"
+  end
+
+  create_table "courses", force: :cascade do |t|
+    t.string "subject"
+    t.integer "teacher_id", null: false
+    t.integer "teacher_assistant_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["teacher_assistant_id"], name: "index_courses_on_teacher_assistant_id"
+    t.index ["teacher_id"], name: "index_courses_on_teacher_id"
+  end
+
   create_table "sessions", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "ip_address"
@@ -29,5 +48,9 @@ ActiveRecord::Schema[8.0].define(version: 2024_10_06_220551) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  add_foreign_key "course_students", "courses"
+  add_foreign_key "course_students", "users", column: "student_id"
+  add_foreign_key "courses", "users", column: "teacher_assistant_id"
+  add_foreign_key "courses", "users", column: "teacher_id"
   add_foreign_key "sessions", "users"
 end

--- a/lib/templates/erb/scaffold/_form.html.erb
+++ b/lib/templates/erb/scaffold/_form.html.erb
@@ -1,0 +1,15 @@
+<%# frozen_string_literal: true %>
+<%%= simple_form_for(@<%= singular_table_name %>) do |f| %>
+  <%%= f.error_notification %>
+  <%%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
+
+  <div class="form-inputs">
+  <%- attributes.each do |attribute| -%>
+    <%%= f.<%= attribute.reference? ? :association : :input %> :<%= attribute.name %> %>
+  <%- end -%>
+  </div>
+
+  <div class="form-actions">
+    <%%= f.button :submit %>
+  </div>
+<%% end %>

--- a/spec/factories/course_students.rb
+++ b/spec/factories/course_students.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :course_student do
+    course
+    student { create(:user, :student) }
+  end
+end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :course do
+    subject { 'math' }
+    teacher { create(:user, :faculty) }
+    teacher_assistant { create(:user, :faculty) }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,18 +2,21 @@ TEST_USER_PASSWORD = 'hard-2-guess'
 
 FactoryBot.define do
   factory :user do
-    email_address { |n| "user#{n}@email.com" }
+    sequence(:email_address) { |n| "user#{n}@email.com" }
     password { TEST_USER_PASSWORD }
 
     trait :administration do
+      sequence(:email_address) { |n| "administration#{n}@email.com" }
       role { :administration }
     end
 
     trait :faculty do
+      sequence(:email_address) { |n| "faculty#{n}@email.com" }
       role { :faculty }
     end
 
     trait :student do
+      sequence(:email_address) { |n| "student#{n}@email.com" }
       role { :student }
     end
   end

--- a/spec/features/administration_creates_course_spec.rb
+++ b/spec/features/administration_creates_course_spec.rb
@@ -1,0 +1,21 @@
+feature 'administration creates course' do
+  scenario 'sucessfully' do
+    _teacher1 = create(:user, :faculty, email_address: 'teacher1@teacher.com')
+    _teacher2 = create(:user, :faculty, email_address: 'teacher2@teacher.com')
+    student1 = create(:user, :student, email_address: 'student1@student.com')
+    student2 = create(:user, :student, email_address: 'student2@student.com')
+
+    sign_in create(:user, :administration)
+    visit root_path
+
+    fill_in 'Subject', with: 'math'
+    select 'teacher1@teacher.com', from: 'Teacher'
+    select 'teacher2@teacher.com', from: 'Teacher assistant'
+    check "course_student_ids_#{student1.id}"
+    check "course_student_ids_#{student2.id}"
+    click_on "Create Course"
+
+    expect(page).to have_content('created')
+    expect(page).to have_content('math teacher1@teacher.com 2')
+  end
+end

--- a/spec/features/administration_sees_course_form_spec.rb
+++ b/spec/features/administration_sees_course_form_spec.rb
@@ -1,0 +1,21 @@
+feature 'administration sees course form' do
+  scenario 'sucessfully' do
+    _teacher1 = create(:user, :faculty, email_address: 'teacher1@teacher.com')
+    _teacher2 = create(:user, :faculty, email_address: 'teacher2@teacher.com')
+    student1 = create(:user, :student, email_address: 'student1@student.com')
+    student2 = create(:user, :student, email_address: 'student2@student.com')
+
+    sign_in create(:user, :administration)
+    visit root_path
+
+    expect(page).to have_css('h2', text: 'Create new course')
+
+    expect(page).to have_field('Subject')
+
+    expect(page).to have_select('Teacher', options: [ 'teacher1@teacher.com', 'teacher2@teacher.com' ])
+    expect(page).to have_select('Teacher assistant', options: [ '', 'teacher1@teacher.com', 'teacher2@teacher.com' ])
+
+    expect(page).to have_field("course_student_ids_#{student1.id}", type: 'checkbox')
+    expect(page).to have_field("course_student_ids_#{student2.id}", type: 'checkbox')
+  end
+end

--- a/spec/features/administration_sees_course_list_spec.rb
+++ b/spec/features/administration_sees_course_list_spec.rb
@@ -1,0 +1,19 @@
+feature 'administration sees course list' do
+  scenario 'sucessfully' do
+    teacher1 = create(:user, :faculty, email_address: 'teacher1@teacher.com')
+    course1 = create(:course, subject: 'math', teacher: teacher1)
+    create(:course_student, course: course1)
+
+    teacher2 = create(:user, :faculty, email_address: 'teacher2@teacher.com')
+    course2 = create(:course, subject: 'history', teacher: teacher2)
+    create_list(:course_student, 3, course: course2)
+
+    sign_in create(:user, :administration)
+    visit root_path
+
+    expect(page).to have_css('h2', text: 'Courses')
+
+    expect(page).to have_content('math teacher1@teacher.com 1')
+    expect(page).to have_content('history teacher2@teacher.com 3')
+  end
+end


### PR DESCRIPTION
# Motivation
Administration users would like to be able to create courses, assign teachers to them, and enroll students in them. Each course has a subject.

# Proposed solution
- create DB table and Rails model for `Course` entity
  - attributes are `subject`, `teacher_id`, and `teacher_assistant_id`
  - teachers are users with `faculty` role
- create DB table and Rails model for `CourseStudent` entity (student enrollment in courses)
  - attributes are `course_id` and `student_id`
  - students are users with `student` role
- add a "Create new course" form to the Administration dashboard so that those users can create courses
- show a list of existing courses in the Administration dashboard so that those users can see existing courses