### PR TITLE
add course list to student dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,7 +1,8 @@
 class DashboardController < ApplicationController
   def index
+    @courses = Course.list_for(authenticated_user)
+
     if authenticated_user.administration?
-      @courses = Course.all
       @new_course = Course.new
       @teachers = User.faculty
       @students = User.student

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3,4 +3,15 @@ class Course < ApplicationRecord
   belongs_to :teacher_assistant, -> { faculty }, class_name: "User", optional: true
   has_many :course_students
   has_many :students, -> { student }, through: :course_students
+
+  def self.list_for(user)
+    case user.role.to_sym
+    when :administration
+      all
+    when :student
+      includes(:students).where(course_students: { student_id: user.id })
+    else
+      []
+    end
+  end
 end

--- a/app/views/dashboard/_student.html.erb
+++ b/app/views/dashboard/_student.html.erb
@@ -1,1 +1,4 @@
 <% content_for(:title) { 'Student Dashboard' } %>
+
+<h2>Courses</h2>
+<%= render 'courses/list' %>

--- a/spec/features/student_sees_course_list_spec.rb
+++ b/spec/features/student_sees_course_list_spec.rb
@@ -1,0 +1,23 @@
+feature 'student sees course list' do
+  scenario 'sucessfully' do
+    student = create(:user, :student)
+
+    teacher1 = create(:user, :faculty, email_address: 'teacher1@teacher.com')
+    course1 = create(:course, subject: 'the course you see', teacher: teacher1)
+    create(:course_student, course: course1, student: student)
+
+    teacher2 = create(:user, :faculty, email_address: 'teacher2@teacher.com')
+    course2 = create(:course, subject: 'the course you do not', teacher: teacher2)
+    create(:course_student, course: course2)
+
+    sign_in student
+    visit root_path
+
+    expect(page).to have_css('h2', text: 'Courses')
+
+    expect(page).to have_content('the course you see teacher1@teacher.com 1')
+
+    expect(page).not_to have_content('the course you do not')
+    expect(page).not_to have_content('teacher2@teacher.com')
+  end
+end


### PR DESCRIPTION
# Motivation
Students would like to see their course list when they sign into the application. They should not see courses they are not enrolled in.

# Proposed solution
Setting the `@courses` variable for everyone with queries specific to each role.
