### PR TITLE
add course list to faculty dashboard

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -10,6 +10,8 @@ class Course < ApplicationRecord
       all
     when :student
       includes(:students).where(course_students: { student_id: user.id })
+    when :faculty
+      where(teacher_id: user.id).or(where(teacher_assistant_id: user.id))
     else
       []
     end

--- a/app/views/dashboard/_faculty.html.erb
+++ b/app/views/dashboard/_faculty.html.erb
@@ -1,1 +1,4 @@
 <% content_for(:title) { 'Faculty Dashboard' } %>
+
+<h2>Courses</h2>
+<%= render 'courses/list' %>

--- a/spec/features/faculty_sees_course_list_spec.rb
+++ b/spec/features/faculty_sees_course_list_spec.rb
@@ -1,0 +1,19 @@
+feature 'faculty sees course list' do
+  scenario 'sucessfully' do
+    teacher = create(:user, :faculty, email_address: 'teacher@teacher.com')
+
+    create(:course, subject: 'a course you see', teacher: teacher)
+    create(:course, subject: 'another course you see', teacher_assistant: teacher)
+    create(:course, subject: 'a course you do not')
+
+    sign_in teacher
+    visit root_path
+
+    expect(page).to have_css('h2', text: 'Courses')
+
+    expect(page).to have_content('a course you see teacher@teacher.com')
+    expect(page).to have_content('another course you see')
+
+    expect(page).not_to have_content('a course you do not')
+  end
+end


### PR DESCRIPTION
# Motivation
Faculty members would like to sign in and see a list of courses showing them the courses they're the teacher or teacher assistant for. They should not see courses where they are neither.

# Proposed solution
Add `faculty` to `Course.list_for` and use it to render courses for faculty.
