### PR TITLE
create TelegramClient

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+TELEGRAM_CLIENT_URL='http://www.telegram-client.com/'

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Ignore all environment files.
 /.env*
+!.env.example
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem "kamal", ">= 2.0.0.rc2", require: false
 gem "thruster", require: false
 
 gem "simple_form"
+gem "faraday"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
@@ -52,6 +53,7 @@ group :development, :test do
   gem "rspec-rails"
   gem "capybara"
   gem "factory_bot_rails"
+  gem "webmock"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,9 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     date (3.3.4)
     debug (1.9.2)
@@ -116,11 +119,18 @@ GEM
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
+    faraday (2.12.0)
+      faraday-net_http (>= 2.0, < 3.4)
+      json
+      logger
+    faraday-net_http (3.3.0)
+      net-http
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashdiff (1.1.1)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.0.3)
@@ -161,6 +171,8 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.1)
     msgpack (1.7.3)
+    net-http (0.4.1)
+      uri
     net-imap (0.4.16)
       date
       net-protocol
@@ -249,6 +261,7 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.10)
       io-console (~> 0.5)
+    rexml (3.3.8)
     rspec-core (3.13.1)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
@@ -354,6 +367,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.24.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.8.2)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -385,6 +402,7 @@ DEPENDENCIES
   capybara
   debug
   factory_bot_rails
+  faraday
   importmap-rails
   jbuilder
   kamal (>= 2.0.0.rc2)
@@ -403,6 +421,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webmock
 
 BUNDLED WITH
    2.5.16

--- a/lib/telegram_client.rb
+++ b/lib/telegram_client.rb
@@ -1,0 +1,17 @@
+class TelegramClient
+  def self.create_group(group_title, link_title)
+    response = connection.post(ENV["TELEGRAM_CLIENT_URL"]) do |request|
+      request.body = { group_title:, link_title: }.to_json
+    end
+
+    JSON.parse(response.body, { symbolize_names: true })
+  rescue StandardError => error
+    Rails.logger.error "TelegramClient error: #{error}"
+
+    {}
+  end
+
+  def self.connection
+    Faraday.new(headers: { "Content-Type" => "application/json" })
+  end
+end

--- a/spec/lib/telegram_client_spec.rb
+++ b/spec/lib/telegram_client_spec.rb
@@ -1,0 +1,40 @@
+describe TelegramClient do
+  describe '.create_group' do
+    context 'when there are no errors' do
+      it 'creates a group with title and link' do
+        stub_request(:post, "http://www.telegram-client.com/").
+          with(
+            body: { group_title: 'Group Title', link_title: 'Link Title' }.to_json
+          ).to_return(
+            headers: {},
+            status: 200,
+            body: { group_title: 'Group Title', link_title: 'Link Title', invite_link: "http://t.me/link-key" }.to_json
+          )
+
+        group = TelegramClient.create_group('Group Title', 'Link Title')
+
+        expect(group[:group_title]).to eq('Group Title')
+        expect(group[:link_title]).to eq('Link Title')
+      end
+    end
+
+    context 'when there are errors' do
+      it 'logs error information' do
+        allow(Faraday).to receive(:new).and_raise(Faraday::Error, 'some rescued error')
+        allow(Rails.logger).to receive(:error).and_call_original
+
+        _group = TelegramClient.create_group('not important', 'not important')
+
+        expect(Rails.logger).to have_received(:error).with('TelegramClient error: some rescued error')
+      end
+
+      it 'returns an empty hash' do
+        allow(Faraday).to receive(:new).and_raise(Faraday::Error, 'some rescued error')
+
+        group = TelegramClient.create_group('not important', 'not important')
+
+        expect(group).to eq({})
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
+require 'webmock/rspec'
+
+require 'dotenv'
+Dotenv.load('.env.example')
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
# Motivation
Administrators would like to be able to create Telegram groups for each course.

# Proposed solution
Step 1 for a feature that creates groups on Telegram is being able to make requests to the API. `TelegramClient` uses `Faraday` to make requests to `telegram-client` and returns the response body as a Ruby hash. `WebMock` helps ensure tests are reliable and consistent.