### PR TITLE
Create telegram group for course

### DIFF
--- a/app/services/CourseService/create_telegram_group.rb
+++ b/app/services/CourseService/create_telegram_group.rb
@@ -1,0 +1,26 @@
+module CourseService
+  class CreateTelegramGroup
+    def initialize(course)
+      @course = course
+    end
+
+    def call
+      return false if @course.telegram_group_link.present?
+
+      group = TelegramClient.create_group(group_title, link_title)
+      return false if group.blank?
+
+      @course.update(telegram_group_link: group[:invite_link])
+    end
+
+    private
+
+    def group_title
+      "##{@course.id} #{@course.subject} #{@course.teacher.email_address}"
+    end
+
+    def link_title
+      "##{@course.id} #{DateTime.current}"
+    end
+  end
+end

--- a/db/migrate/20241017194407_add_telegram_group_link_to_course.rb
+++ b/db/migrate/20241017194407_add_telegram_group_link_to_course.rb
@@ -1,0 +1,5 @@
+class AddTelegramGroupLinkToCourse < ActiveRecord::Migration[8.0]
+  def change
+    add_column :courses, :telegram_group_link, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_10_06_234624) do
+ActiveRecord::Schema[8.0].define(version: 2024_10_17_194407) do
   create_table "course_students", force: :cascade do |t|
     t.integer "course_id", null: false
     t.integer "student_id", null: false
@@ -26,6 +26,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_10_06_234624) do
     t.integer "teacher_assistant_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "telegram_group_link"
     t.index ["teacher_assistant_id"], name: "index_courses_on_teacher_assistant_id"
     t.index ["teacher_id"], name: "index_courses_on_teacher_id"
   end

--- a/spec/services/course_service/create_telegram_group_spec.rb
+++ b/spec/services/course_service/create_telegram_group_spec.rb
@@ -1,0 +1,29 @@
+describe CourseService::CreateTelegramGroup do
+  describe '.call' do
+    it 'does not create a group for a course with a link' do
+      allow(TelegramClient).to receive(:create_group).and_call_original
+      course = create(:course, telegram_group_link: 'https://t.me/a-link-is-here')
+      create_group = CourseService::CreateTelegramGroup.new(course)
+
+      expect(create_group.call).to eq(false)
+      expect(TelegramClient).not_to have_received(:create_group)
+    end
+
+    it 'returns false when TelegramClient returns empty hash' do
+      allow(TelegramClient).to receive(:create_group).and_return({})
+      course = create(:course)
+      create_group = CourseService::CreateTelegramGroup.new(course)
+
+      expect(create_group.call).to eq(false)
+    end
+
+    it 'updates the record with the invite link when successful' do
+      allow(TelegramClient).to receive(:create_group).and_return({ invite_link: 'https://t.me/a-link-is-here' })
+      course = create(:course)
+      create_group = CourseService::CreateTelegramGroup.new(course)
+
+      expect(create_group.call).to eq(true)
+      expect(course.reload.telegram_group_link).to eq('https://t.me/a-link-is-here')
+    end
+  end
+end

--- a/spec/services/course_service/create_telegram_group_spec.rb
+++ b/spec/services/course_service/create_telegram_group_spec.rb
@@ -9,6 +9,17 @@ describe CourseService::CreateTelegramGroup do
       expect(TelegramClient).not_to have_received(:create_group)
     end
 
+    it 'generates group and link titles based on course information' do
+      allow(TelegramClient).to receive(:create_group).and_return({ something: 'irrelevant' })
+      allow(DateTime).to receive(:current).and_return('2024-10-31T23:59:59+00:00')
+      teacher = create(:user, :faculty, email_address: 'this-teacher@faculty.com')
+      course = create(:course, id: 549, subject: 'PE', teacher: teacher)
+
+      CourseService::CreateTelegramGroup.new(course).call
+
+      expect(TelegramClient).to have_received(:create_group).with('#549 PE this-teacher@faculty.com', '#549 2024-10-31T23:59:59+00:00')
+    end
+
     it 'returns false when TelegramClient returns empty hash' do
       allow(TelegramClient).to receive(:create_group).and_return({})
       course = create(:course)


### PR DESCRIPTION
# Motivation
Administrators would like to be able to create Telegram groups for each course.

# Proposed solution
(https://github.com/vivipoit/school-telegram/pull/10 was Step 1 for this feature.)
Step 2 for this feature is a service that:
- takes a `course` object as parameter
- makes sure the course does not already have a Telegram group created
- generates group and link titles based on the course information
- calls `TelegramClient` to create the group
- persists the `invite_link` on the database (new column on table `courses`)