### PR TITLE
Administrators create telegram groups

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -7,6 +7,15 @@ class CoursesController < ApplicationController
     redirect_to root_path, alert: alert
   end
 
+  def create_telegram_group
+    @course = Course.find(params[:id])
+    create_group = CourseService::CreateTelegramGroup.new(@course)
+
+    alert = create_group.call ? "created" : "failed"
+
+    redirect_to root_path, alert: alert
+  end
+
   private
 
   def course_params

--- a/app/helpers/course_helper.rb
+++ b/app/helpers/course_helper.rb
@@ -1,0 +1,9 @@
+module CourseHelper
+  def course_telegram_group_link(course)
+    if course.telegram_group_link.present?
+      link_to "join telegram group", course.telegram_group_link, target: "_blank"
+    elsif authenticated_user.administration?
+      button_to "create telegram group", create_telegram_group_course_path(course)
+    end
+  end
+end

--- a/app/views/courses/_list.html.erb
+++ b/app/views/courses/_list.html.erb
@@ -1,5 +1,10 @@
 <ul>
   <% @courses.each do |course| %>
-    <li><%= course.subject %> <%= course.teacher.email_address %> <%= course.students.count %></li>
+    <li>
+      <%= course.subject %>
+      <%= course.teacher.email_address %>
+      <%= course.students.count %>
+      <%= course_telegram_group_link(course) %>
+    </li>
   <% end %>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,11 @@
 Rails.application.routes.draw do
   resource :session, except: [ :destroy ]
   resources :passwords, param: :token
-  resources :courses, only: [ :create ]
+  resources :courses, only: [ :create ] do
+    member do
+      post :create_telegram_group
+    end
+  end
 
   get "sign_out" => "sessions#destroy", as: :sign_out
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/spec/features/administration_creates_telegram_group_spec.rb
+++ b/spec/features/administration_creates_telegram_group_spec.rb
@@ -1,0 +1,13 @@
+feature 'administration creates Telegram group' do
+  scenario 'sucessfully' do
+    create(:course)
+
+    sign_in create(:user, :administration)
+    visit root_path
+
+    click_on 'create telegram group'
+
+    expect(page).to have_content('created')
+    expect(page).to have_link('join telegram group')
+  end
+end

--- a/spec/features/administration_sees_course_list_spec.rb
+++ b/spec/features/administration_sees_course_list_spec.rb
@@ -5,8 +5,8 @@ feature 'administration sees course list' do
     create(:course_student, course: course1)
 
     teacher2 = create(:user, :faculty, email_address: 'teacher2@teacher.com')
-    course2 = create(:course, subject: 'history', teacher: teacher2)
-    create_list(:course_student, 3, course: course2)
+    course2 = create(:course, subject: 'history', teacher: teacher2, telegram_group_link: 'https://t.me/this-fun-link')
+    create_list(:course_student, 25, course: course2)
 
     sign_in create(:user, :administration)
     visit root_path
@@ -14,6 +14,7 @@ feature 'administration sees course list' do
     expect(page).to have_css('h2', text: 'Courses')
 
     expect(page).to have_content('math teacher1@teacher.com 1')
-    expect(page).to have_content('history teacher2@teacher.com 3')
+    expect(page).to have_button('create telegram group')
+    expect(page).to have_content('history teacher2@teacher.com 25 join telegram group')
   end
 end

--- a/spec/features/faculty_sees_course_list_spec.rb
+++ b/spec/features/faculty_sees_course_list_spec.rb
@@ -2,7 +2,7 @@ feature 'faculty sees course list' do
   scenario 'sucessfully' do
     teacher = create(:user, :faculty, email_address: 'teacher@teacher.com')
 
-    create(:course, subject: 'a course you see', teacher: teacher)
+    create(:course, subject: 'a course you see', teacher: teacher, telegram_group_link: 'https://t.me/this-fun-link')
     create(:course, subject: 'another course you see', teacher_assistant: teacher)
     create(:course, subject: 'a course you do not')
 
@@ -11,9 +11,10 @@ feature 'faculty sees course list' do
 
     expect(page).to have_css('h2', text: 'Courses')
 
-    expect(page).to have_content('a course you see teacher@teacher.com')
+    expect(page).to have_content('a course you see teacher@teacher.com 0 join telegram group')
     expect(page).to have_content('another course you see')
 
     expect(page).not_to have_content('a course you do not')
+    expect(page).not_to have_button('create telegram group')
   end
 end

--- a/spec/features/student_sees_course_list_spec.rb
+++ b/spec/features/student_sees_course_list_spec.rb
@@ -3,21 +3,26 @@ feature 'student sees course list' do
     student = create(:user, :student)
 
     teacher1 = create(:user, :faculty, email_address: 'teacher1@teacher.com')
-    course1 = create(:course, subject: 'the course you see', teacher: teacher1)
+    course1 = create(:course, subject: 'the course you see', teacher: teacher1, telegram_group_link: 'https://t.me/this-fun-link')
     create(:course_student, course: course1, student: student)
 
-    teacher2 = create(:user, :faculty, email_address: 'teacher2@teacher.com')
-    course2 = create(:course, subject: 'the course you do not', teacher: teacher2)
-    create(:course_student, course: course2)
+    course2 = create(:course, subject: 'another course you see')
+    create(:course_student, course: course2, student: student)
+
+    teacher3 = create(:user, :faculty, email_address: 'teacher3@teacher.com')
+    course3 = create(:course, subject: 'the course you do not see', teacher: teacher3)
+    create(:course_student, course: course3)
 
     sign_in student
     visit root_path
 
     expect(page).to have_css('h2', text: 'Courses')
 
-    expect(page).to have_content('the course you see teacher1@teacher.com 1')
+    expect(page).to have_content('the course you see teacher1@teacher.com 1 join telegram group')
+    expect(page).to have_content('another course you see')
 
-    expect(page).not_to have_content('the course you do not')
-    expect(page).not_to have_content('teacher2@teacher.com')
+    expect(page).not_to have_content('the course you do not see')
+    expect(page).not_to have_content('teacher3@teacher.com')
+    expect(page).not_to have_button('create telegram group')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,4 +13,9 @@ RSpec.configure do |config|
   end
 
   config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  config.before(type: :feature) do
+    stub_request(:post, "http://www.telegram-client.com/")
+      .to_return(status: 200, body: { invite_link: 'https://t.me/a-fun-link' }.to_json, headers: {})
+  end
 end


### PR DESCRIPTION
# Motivation
Administrators would like to be able to create Telegram groups for each course.

# Proposed solution
(https://github.com/vivipoit/school-telegram/pull/10 and https://github.com/vivipoit/school-telegram/pull/12 were Steps 1 and 2 for this feature.)
Step 3 - the final step - for this feature is giving the user a button to click for creating the group. The button triggers a POST request to a controller action that calls the logic implemented previously.

The `CourseHelper` rudimentarily helps deliver 2 enhancements beyond simple group creation:
- The button is not rendered for courses that already have an invite link configured. The link itself is offered instead.
- The button is never rendered for non-administrator users.